### PR TITLE
Proton track (+ extra info) data format definition

### DIFF
--- a/DataFormats/ProtonReco/BuildFile.xml
+++ b/DataFormats/ProtonReco/BuildFile.xml
@@ -1,0 +1,5 @@
+<use name="DataFormats/Common"/>
+<use name="DataFormats/TrackReco"/>
+<export>
+  <lib name="1"/>
+</export>

--- a/DataFormats/ProtonReco/interface/ProtonTrack.h
+++ b/DataFormats/ProtonReco/interface/ProtonTrack.h
@@ -1,0 +1,44 @@
+/****************************************************************************
+ *
+ * This is a part of CTPPS offline software.
+ * Authors:
+ *   Jan Kašpar
+ *   Laurent Forthomme
+ *
+ ****************************************************************************/
+
+#ifndef DataFormats_ProtonReco_ProtonTrack_h
+#define DataFormats_ProtonReco_ProtonTrack_h
+
+#include "DataFormats/TrackReco/interface/Track.h"
+#include "DataFormats/ProtonReco/interface/ProtonTrackExtraFwd.h"
+#include <set>
+
+namespace reco
+{
+  class ProtonTrack : public Track
+  {
+    public:
+      /// Default constructor
+      ProtonTrack();
+      /// Constructor from refit parameters, fitted vertex and direction, and longitudinal fractional momentum loss
+      ProtonTrack( double chi2, double ndof, const Point& vtx, const Vector& dir, float xi, const CovarianceMatrix& cov = CovarianceMatrix() );
+
+      /// Indices to the covariance matrix
+      enum struct Index : unsigned short { xi, th_x, th_y, vtx_y, num_indices };
+
+      /// Longitudinal fractional momentum loss
+      float xi() const { return xi_; }
+      /// Absolute uncertainty on longitudinal fractional momentum loss
+      float xiError() const { return error( (int)Index::xi ); }
+
+      void setProtonTrackExtra( const ProtonTrackExtraRef& ref ) { pt_extra_ = ref; }
+      const ProtonTrackExtraRef& protonTrackExtra() const { return pt_extra_; }
+
+    private:
+      float xi_; ///< Longitudinal fractional momentum loss
+      ProtonTrackExtraRef pt_extra_; ///< Additional information on proton track
+  };
+}
+
+#endif

--- a/DataFormats/ProtonReco/interface/ProtonTrackExtra.h
+++ b/DataFormats/ProtonReco/interface/ProtonTrackExtra.h
@@ -1,0 +1,58 @@
+/****************************************************************************
+ *
+ * This is a part of CTPPS offline software.
+ * Authors:
+ *   Jan Kašpar
+ *   Laurent Forthomme
+ *
+ ****************************************************************************/
+
+#ifndef DataFormats_ProtonReco_ProtonTrackExtra_h
+#define DataFormats_ProtonReco_ProtonTrackExtra_h
+
+#include <set>
+#include "DataFormats/Common/interface/Ref.h"
+
+namespace reco
+{
+  class ProtonTrackExtra
+  {
+    public:
+      typedef std::set<unsigned int> RPList;
+      /// Type of reconstruction for this track
+      enum class ReconstructionMethod { invalid = -1, singleRP, multiRP };
+      /// LHC sector for this track
+      enum class LHCSector { invalid = -1, sector45, sector56 };
+
+      /// Empty (invalid track extra info) constructor
+      ProtonTrackExtra();
+      /// Default constructor
+      ProtonTrackExtra( bool valid, const ReconstructionMethod& method, const LHCSector& sector, const RPList& rp_list );
+
+      /// Set the flag for the fit validity
+      void setValidFit( bool valid = true ) { valid_fit_ = valid; }
+      /// Flag for the fit validity
+      bool validFit() const { return valid_fit_; }
+      /// Set the reconstruction method for this track
+      void setMethod( const ReconstructionMethod& method ) { method_ = method; }
+      /// Reconstruction method for this track
+      ReconstructionMethod method() const { return method_; }
+      /// Set the LHC sector (0=sector45, 1=sector56)
+      void setSector( const LHCSector& sector ) { sector_ = sector; }
+      /// LHC sector for this track (0=sector45, 1=sector56)
+      LHCSector sector() const { return sector_; }
+      /// Store the list of RP tracks that contributed to this global track
+      void setContributingRPs( const RPList& list ) { contributing_rp_ids_ = list; }
+      /// List of RP tracks that contributed to this global track
+      const RPList& contributingRPs() const { return contributing_rp_ids_; }
+
+    private:
+      bool valid_fit_;
+      ReconstructionMethod method_;
+      LHCSector sector_;
+      RPList contributing_rp_ids_;
+  };
+}
+
+#endif
+

--- a/DataFormats/ProtonReco/interface/ProtonTrackExtraFwd.h
+++ b/DataFormats/ProtonReco/interface/ProtonTrackExtraFwd.h
@@ -1,0 +1,33 @@
+/****************************************************************************
+ *
+ * This is a part of CTPPS offline software.
+ * Authors:
+ *   Jan Kašpar
+ *   Laurent Forthomme
+ *
+ ****************************************************************************/
+
+#ifndef DataFormats_ProtonReco_ProtonTrackExtraFwd_h
+#define DataFormats_ProtonReco_ProtonTrackExtraFwd_h
+
+#include "DataFormats/Common/interface/Ref.h"
+#include "DataFormats/Common/interface/RefProd.h"
+#include "DataFormats/Common/interface/RefVector.h"
+
+#include <vector>
+
+namespace reco
+{
+  class ProtonTrackExtra;
+  /// Collection of ProtonTrackExtra objects
+  typedef std::vector<ProtonTrackExtra> ProtonTrackExtraCollection;
+  /// Persistent reference to a ProtonTrackExtra
+  typedef edm::Ref<ProtonTrackExtraCollection> ProtonTrackExtraRef;
+  /// Reference to a ProtonTrackExtra collection
+  typedef edm::RefProd<ProtonTrackExtraCollection> ProtonTrackExtraRefProd;
+  /// Vector of references to ProtonTrackExtra in the same collection
+  typedef edm::RefVector<ProtonTrackExtraCollection> ProtonTrackExtraRefVector;
+}
+
+#endif
+

--- a/DataFormats/ProtonReco/interface/ProtonTrackFwd.h
+++ b/DataFormats/ProtonReco/interface/ProtonTrackFwd.h
@@ -1,0 +1,33 @@
+/****************************************************************************
+ *
+ * This is a part of CTPPS offline software.
+ * Authors:
+ *   Jan Kašpar
+ *   Laurent Forthomme
+ *
+ ****************************************************************************/
+
+#ifndef DataFormats_ProtonReco_ProtonTrackFwd_h
+#define DataFormats_ProtonReco_ProtonTrackFwd_h
+
+#include "DataFormats/Common/interface/Ref.h"
+#include "DataFormats/Common/interface/RefProd.h"
+#include "DataFormats/Common/interface/RefVector.h"
+
+#include <vector>
+
+namespace reco
+{
+  class ProtonTrack;
+  /// Collection of ProtonTrack objects
+  typedef std::vector<ProtonTrack> ProtonTrackCollection;
+  /// Persistent reference to a ProtonTrack
+  typedef edm::Ref<ProtonTrackCollection> ProtonTrackRef;
+  /// Reference to a ProtonTrack collection
+  typedef edm::RefProd<ProtonTrackCollection> ProtonTrackRefProd;
+  /// Vector of references to ProtonTrack in the same collection
+  typedef edm::RefVector<ProtonTrackCollection> ProtonTrackRefVector;
+}
+
+#endif
+

--- a/DataFormats/ProtonReco/src/ProtonTrack.cc
+++ b/DataFormats/ProtonReco/src/ProtonTrack.cc
@@ -1,0 +1,23 @@
+/****************************************************************************
+ *
+ * This is a part of CTPPS offline software.
+ * Authors:
+ *   Jan Kašpar
+ *   Laurent Forthomme
+ *
+ ****************************************************************************/
+
+#include "DataFormats/ProtonReco/interface/ProtonTrack.h"
+
+#include <set>
+
+using namespace reco;
+
+ProtonTrack::ProtonTrack() :
+  xi_( 0. )
+{}
+
+ProtonTrack::ProtonTrack( double chi2, double ndof, const Point& vtx, const Vector& dir, float xi, const CovarianceMatrix& cov ) :
+  Track( chi2, ndof, vtx, dir, +1, cov ), xi_( xi )
+{}
+

--- a/DataFormats/ProtonReco/src/ProtonTrackExtra.cc
+++ b/DataFormats/ProtonReco/src/ProtonTrackExtra.cc
@@ -1,0 +1,21 @@
+/****************************************************************************
+ *
+ * This is a part of CTPPS offline software.
+ * Authors:
+ *   Jan Kašpar
+ *   Laurent Forthomme
+ *
+ ****************************************************************************/
+
+#include "DataFormats/ProtonReco/interface/ProtonTrackExtra.h"
+
+using namespace reco;
+
+ProtonTrackExtra::ProtonTrackExtra() :
+  valid_fit_( false ), method_( ReconstructionMethod::invalid ), sector_( LHCSector::invalid )
+{}
+
+ProtonTrackExtra::ProtonTrackExtra( bool valid, const ReconstructionMethod& method, const LHCSector& sector, const RPList& rp_list ) :
+  valid_fit_( valid ), method_( method ), sector_( sector ), contributing_rp_ids_( rp_list )
+{}
+

--- a/DataFormats/ProtonReco/src/classes.h
+++ b/DataFormats/ProtonReco/src/classes.h
@@ -1,0 +1,33 @@
+#include "DataFormats/ProtonReco/interface/ProtonTrack.h"
+#include "DataFormats/ProtonReco/interface/ProtonTrackFwd.h"
+#include "DataFormats/ProtonReco/interface/ProtonTrackExtra.h"
+#include "DataFormats/ProtonReco/interface/ProtonTrackExtraFwd.h"
+
+#include "DataFormats/Common/interface/Ptr.h"
+#include "DataFormats/Common/interface/View.h"
+#include "DataFormats/Common/interface/Wrapper.h"
+
+#include <vector>
+#include <set>
+
+namespace DataFormats_ProtonReco
+{
+  struct dictionary
+  {
+    reco::ProtonTrack pt;
+    std::vector<reco::ProtonTrack> vec_pt;
+    edm::Wrapper<std::vector<reco::ProtonTrack> > wrp_vec_pt;
+    edm::RefProd<std::vector<reco::ProtonTrack> > rp_vec_pt;
+    edm::Ref<std::vector<reco::ProtonTrack>,reco::ProtonTrack,edm::refhelper::FindUsingAdvance<std::vector<reco::ProtonTrack>,reco::ProtonTrack> > ref_vec_pt;
+    edm::RefVector<std::vector<reco::ProtonTrack>,reco::ProtonTrack,edm::refhelper::FindUsingAdvance<std::vector<reco::ProtonTrack>,reco::ProtonTrack> > rv_vec_pt;
+
+    reco::ProtonTrackExtra pte;
+    std::vector<reco::ProtonTrackExtra> vec_pte;
+    edm::Wrapper<std::vector<reco::ProtonTrackExtra> > wrp_vec_pte;
+    edm::RefProd<std::vector<reco::ProtonTrackExtra> > rp_vec_pte;
+    edm::Ref<std::vector<reco::ProtonTrackExtra>,reco::ProtonTrackExtra,edm::refhelper::FindUsingAdvance<std::vector<reco::ProtonTrackExtra>,reco::ProtonTrackExtra> > ref_vec_pte;
+    edm::RefVector<std::vector<reco::ProtonTrackExtra>,reco::ProtonTrackExtra,edm::refhelper::FindUsingAdvance<std::vector<reco::ProtonTrackExtra>,reco::ProtonTrackExtra> > rv_vec_pte;
+
+    std::set<unsigned int> set_uint;
+  };
+}

--- a/DataFormats/ProtonReco/src/classes_def.xml
+++ b/DataFormats/ProtonReco/src/classes_def.xml
@@ -1,0 +1,23 @@
+<lcgdict>
+  <class name="reco::ProtonTrack" ClassVersion="3">
+    <version ClassVersion="3" checksum="3525082585"/>
+  </class>
+  <class name="std::vector<reco::ProtonTrack>"/>
+  <class name="edm::Wrapper<std::vector<reco::ProtonTrack> >"/>
+  <class name="edm::RefProd<std::vector<reco::ProtonTrack> >"/>
+  <class name="edm::Ref<std::vector<reco::ProtonTrack>,reco::ProtonTrack,edm::refhelper::FindUsingAdvance<std::vector<reco::ProtonTrack>,reco::ProtonTrack> >"/>
+  <class name="edm::RefVector<std::vector<reco::ProtonTrack>,reco::ProtonTrack,edm::refhelper::FindUsingAdvance<std::vector<reco::ProtonTrack>,reco::ProtonTrack> >"/>
+
+  <class name="reco::ProtonTrackExtra" ClassVersion="3">
+    <version ClassVersion="3" checksum="1360045830"/>
+    <field name="contributing_rp_ids_" iotype="std::set<unsigned int>"/>
+  </class>
+  <class name="std::vector<reco::ProtonTrackExtra>"/>
+  <class name="edm::Wrapper<std::vector<reco::ProtonTrackExtra> >"/>
+  <class name="edm::RefProd<std::vector<reco::ProtonTrackExtra> >"/>
+  <class name="edm::Ref<std::vector<reco::ProtonTrackExtra>,reco::ProtonTrackExtra,edm::refhelper::FindUsingAdvance<std::vector<reco::ProtonTrackExtra>,reco::ProtonTrackExtra> >"/>
+  <class name="edm::RefVector<std::vector<reco::ProtonTrackExtra>,reco::ProtonTrackExtra,edm::refhelper::FindUsingAdvance<std::vector<reco::ProtonTrackExtra>,reco::ProtonTrackExtra> >"/>
+
+  <class name="std::set<unsigned int>"/>
+
+</lcgdict>

--- a/git-commands.sh
+++ b/git-commands.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+
+git cms-addpkg CondCore/CTPPSPlugins CondFormats/CTPPSReadoutObjects CondFormats/DataRecord
+git cms-addpkg DataFormats/ProtonReco


### PR DESCRIPTION
Overly simplistic PR for a definition of the `reco::ProtonTrack` and associated `reco::ProtonTrackExtra` objects to be used as final products in tracks reconstruction.
The other part for the filling and linking between the two will appear in a later stage.