### PR TITLE
AlignmentFactory helper object

### DIFF
--- a/DataFormats/ProtonReco/BuildFile.xml
+++ b/DataFormats/ProtonReco/BuildFile.xml
@@ -1,5 +1,6 @@
 <use name="DataFormats/Common"/>
 <use name="DataFormats/TrackReco"/>
+<use name="clhep"/>
 <export>
   <lib name="1"/>
 </export>

--- a/RecoCTPPS/ProtonReconstruction/BuildFile.xml
+++ b/RecoCTPPS/ProtonReconstruction/BuildFile.xml
@@ -1,0 +1,5 @@
+<use name="FWCore/Utilities"/>
+<use name="DataFormats/Provenance"/>
+<export>
+  <lib name="1"/>
+</export>

--- a/RecoCTPPS/ProtonReconstruction/interface/AlignmentsFactory.h
+++ b/RecoCTPPS/ProtonReconstruction/interface/AlignmentsFactory.h
@@ -1,0 +1,50 @@
+/****************************************************************************
+ *
+ * This is a part of PPS offline software.
+ * Author:
+ *   Laurent Forthomme
+ *
+ ****************************************************************************/
+
+#ifndef RecoCTPPSAnalysis_ProtonReconstruction_AlignmentsFactory_h
+#define RecoCTPPSAnalysis_ProtonReconstruction_AlignmentsFactory_h
+
+#include "DataFormats/Provenance/interface/EventRange.h"
+
+#include <vector>
+#include <map>
+#include <regex>
+
+namespace pps
+{
+  struct alignment_t
+  {
+    double x_align, x_align_err;
+    double y_align, y_align_err;
+  };
+  typedef std::map<unsigned short,alignment_t> alignments_t;
+  std::ostream& operator<<( std::ostream& os, const alignment_t al );
+  std::ostream& operator<<( std::ostream& os, const alignments_t als );
+
+  class AlignmentsFactory
+  {
+    public:
+      AlignmentsFactory( const std::string& filename );
+      ~AlignmentsFactory() = default;
+
+      const alignments_t& get( unsigned short fill_num ) const;
+
+    private:
+      struct runbased_alignments_t
+      {
+        edm::EventRange fill_range;
+        alignments_t alignments;
+      };
+      static const std::regex RGX_HEADER, RGX_ALIGN;
+
+      std::vector<runbased_alignments_t> alignments_;
+  };
+}
+
+#endif
+

--- a/RecoCTPPS/ProtonReconstruction/plugins/BuildFile.xml
+++ b/RecoCTPPS/ProtonReconstruction/plugins/BuildFile.xml
@@ -1,0 +1,6 @@
+<use name="FWCore/Framework"/>
+<use name="FWCore/PluginManager"/>
+<use name="FWCore/ParameterSet"/>
+<use name="clhep"/>
+<use name="RecoCTPPS/ProtonReconstruction"/>
+<flags EDM_PLUGIN="1"/>

--- a/RecoCTPPS/ProtonReconstruction/plugins/ProtonReconstruction.cc
+++ b/RecoCTPPS/ProtonReconstruction/plugins/ProtonReconstruction.cc
@@ -1,0 +1,83 @@
+/****************************************************************************
+ *
+ * This is a part of CTPPS offline software.
+ * Authors:
+ *   Jan Kašpar
+ *   Laurent Forthomme
+ *
+ ****************************************************************************/
+
+#include <memory>
+
+#include "FWCore/Framework/interface/Frameworkfwd.h"
+#include "FWCore/Framework/interface/stream/EDProducer.h"
+
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/Utilities/interface/StreamID.h"
+
+#include "DataFormats/CTPPSDetId/interface/CTPPSDetId.h"
+#include "DataFormats/CTPPSReco/interface/CTPPSLocalTrackLite.h"
+
+#include "DataFormats/ProtonReco/interface/ProtonTrack.h"
+#include "DataFormats/ProtonReco/interface/ProtonTrackFwd.h"
+#include "DataFormats/ProtonReco/interface/ProtonTrackExtra.h"
+
+#include "RecoCTPPS/ProtonReconstruction/interface/AlignmentsFactory.h"
+
+class ProtonReconstruction : public edm::stream::EDProducer<>
+{
+  public:
+    explicit ProtonReconstruction( const edm::ParameterSet& );
+    ~ProtonReconstruction() = default;
+
+    static void fillDescriptions( edm::ConfigurationDescriptions& descriptions );
+
+  private:
+    void produce( edm::Event&, const edm::EventSetup& ) override;
+
+    edm::EDGetTokenT<std::vector<CTPPSLocalTrackLite> > tracksToken_;
+    pps::AlignmentsFactory align_;
+};
+
+ProtonReconstruction::ProtonReconstruction( const edm::ParameterSet& iConfig ) :
+  tracksToken_( consumes<std::vector<CTPPSLocalTrackLite> >( iConfig.getParameter<edm::InputTag>( "localTrackLiteTag" ) ) ),
+  align_( iConfig.getParameter<edm::FileInPath>( "alignmentFilePath" ).fullPath() )
+{
+  produces<reco::ProtonTrackCollection>();
+  produces<reco::ProtonTrackExtraCollection>();
+}
+
+void
+ProtonReconstruction::produce( edm::Event& iEvent, const edm::EventSetup& iSetup )
+{
+  edm::Handle<std::vector<CTPPSLocalTrackLite> > tracks;
+  iEvent.getByToken( tracksToken_, tracks );
+
+  reco::ProtonTrackExtraRefProd r_extras = iEvent.getRefBeforePut<reco::ProtonTrackExtraCollection>();
+  std::unique_ptr<reco::ProtonTrackCollection> output( new reco::ProtonTrackCollection );
+  std::unique_ptr<reco::ProtonTrackExtraCollection> extras( new reco::ProtonTrackExtraCollection );
+
+  unsigned short fill_number = 0;
+
+  std::for_each( tracks->begin(), tracks->end(), [this,&fill_number]( const CTPPSLocalTrackLite& trk ) {
+    const auto& align_per_pot = align_.get( fill_number );
+  } );
+}
+
+void
+ProtonReconstruction::fillDescriptions( edm::ConfigurationDescriptions& descriptions )
+{
+  edm::ParameterSetDescription desc;
+  desc.add<edm::InputTag>( "localTrackLiteTag", edm::InputTag( "ctppsLocalTrackLiteProducer" ) )
+    ->setComment( "input lite local tracks collection" );
+  desc.add<edm::FileInPath>( "alignmentFilePath", edm::FileInPath( "RecoCTPPS/ProtonReconstruction/data/collect_alignments_2017_01_17.out" ) )
+    ->setComment( "per-pot alignments table" );
+
+  descriptions.add( "protontracks", desc );
+}
+
+DEFINE_FWK_MODULE( ProtonReconstruction );
+

--- a/RecoCTPPS/ProtonReconstruction/src/AlignmentsFactory.cc
+++ b/RecoCTPPS/ProtonReconstruction/src/AlignmentsFactory.cc
@@ -1,0 +1,90 @@
+/****************************************************************************
+ *
+ * This is a part of PPS offline software.
+ * Author:
+ *   Laurent Forthomme
+ *
+ ****************************************************************************/
+
+#include "RecoCTPPS/ProtonReconstruction/interface/AlignmentsFactory.h"
+#include "FWCore/Utilities/interface/Exception.h"
+
+#include <fstream>
+
+using namespace pps;
+
+namespace pps
+{
+  std::ostream&
+  operator<<( std::ostream& os, const alignment_t al )
+  {
+    return os
+      << "{x=" << al.x_align << "+/-" << al.x_align_err
+      << ";y=" << al.y_align << "+/-" << al.y_align_err << "}";
+  }
+  std::ostream&
+  operator<<( std::ostream& os, const alignments_t als )
+  {
+    os << "alignments[";
+    for ( const auto& al : als )
+      os << "\npot=" << al.first << ",align=" << al.second;
+    return os << "]\n";
+  }
+}
+
+const std::regex AlignmentsFactory::RGX_HEADER( "\\[\\w+\\/fill_(\\d+)\\/.+\\]" );
+const std::regex AlignmentsFactory::RGX_ALIGN( "id=(\\d+),sh_x=([0-9.+-]+)(?:,sh_x_unc=([0-9.+-]+),sh_y=([0-9.+-]+),sh_y_unc=([0-9.+-]+))?" );
+
+AlignmentsFactory::AlignmentsFactory( const std::string& filename )
+{
+  std::ifstream file( filename );
+  if ( !file.is_open() )
+    throw cms::Exception( "pps:AlignmentsFactory" )
+      << "Failed to open alignment file \"" << filename << "\".";
+
+  unsigned short fill_beg = 0;
+  runbased_alignments_t last_alignments;
+  std::string line;
+  std::smatch match;
+
+  while ( true ) {
+    std::getline( file, line );
+    if ( ( fill_beg > 0 && std::regex_match( line, match, RGX_HEADER ) && match.size() == 2 ) || file.eof() ) {
+      //--- new fill information, or reached the end of file
+      const unsigned short fill_end = file.eof()
+        ? edm::EventID::maxRunNumber()
+        : std::stoi( match[1].str() );
+      last_alignments.fill_range = edm::EventRange( fill_beg, 1, 1, fill_end, edm::EventID::maxLuminosityBlockNumber(), edm::EventID::maxEventNumber() );
+      alignments_.emplace_back( last_alignments );
+      //--- prepare for the next fill
+      last_alignments.alignments.clear();
+      fill_beg = fill_end;
+    }
+    else if ( std::regex_match( line, match, RGX_ALIGN ) && match.size() > 0 ) {
+      //--- parse new alignment parameters
+      const unsigned short pot = std::stoi( match[1].str() );
+      const float align_x     = match.size() > 2 ? std::stof( match[2].str() ) : 0.;
+      const float err_align_x = match.size() > 3 ? std::stof( match[3].str() ) : 0.;
+      const float align_y     = match.size() > 4 ? std::stof( match[4].str() ) : 0.;
+      const float err_align_y = match.size() > 5 ? std::stof( match[5].str() ) : 0.;
+      last_alignments.alignments[pot] = { align_x, err_align_x, align_y, err_align_y };
+    }
+    else
+      throw cms::Exception( "pps:AlignmentsFactory" )
+        << "Failed to parse the following line:\n\t" << line;
+  }
+}
+
+const alignments_t&
+AlignmentsFactory::get( unsigned short fill_num ) const
+{
+  edm::EventID tmp( fill_num, 1, 1 );
+  const auto& it = std::find_if( alignments_.begin(), alignments_.end(), [&tmp]( const runbased_alignments_t& rb_align ) {
+    return edm::contains( rb_align.fill_range, tmp );
+  } );
+  if ( it != alignments_.end() )
+    return it->alignments;
+  throw cms::Exception( "pps:AlignmentsFactory" )
+    << "Failed to retrieve alignment parameters for fill #" << fill_num << ".";
+}
+


### PR DESCRIPTION
As possible utility for our developments, here is my "compact" implementation of an `AlignmentsFactory` object to handle the ASCII per-pot, per-period alignment parameters provided by Jan et al.
For illustration I added a potential use case in a ProtonReconstruction plugin skeletton.

Not necessarily meant to be merged, just putting it in there if that can be any useful...