### PR TITLE
Turn on T2 DQM plots only in special run

### DIFF
--- a/DQM/CTPPS/plugins/TotemT2DQMSource.cc
+++ b/DQM/CTPPS/plugins/TotemT2DQMSource.cc
@@ -252,6 +252,9 @@ void TotemT2DQMSource::analyze(const edm::Event& iEvent, const edm::EventSetup& 
     // fill digis information
     std::unordered_map<unsigned int, std::set<unsigned int>> planes;
 
+    if (!iEvent.getHandle(digiToken_).isValid())
+      return;
+
     for (const auto& ds_digis : iEvent.get(digiToken_)) {
       if (!ds_digis.empty()) {
         const TotemT2DetId detid(ds_digis.detId());

--- a/DQM/CTPPS/python/totemT2DQMSource_cfi.py
+++ b/DQM/CTPPS/python/totemT2DQMSource_cfi.py
@@ -5,6 +5,7 @@ totemT2DQMSource = DQMEDAnalyzer('TotemT2DQMSource',
     digisTag = cms.InputTag('totemT2Digis', 'TotemT2'),
     nbinsx = cms.uint32(25),
     nbinsy = cms.uint32(25),
+    specialRunT2 = cms.bool(False),
     windowsNum = cms.uint32(8),
 
     perLSsaving = cms.untracked.bool(False), #driven by DQMServices/Core/python/DQMStore_cfi.py

--- a/DQM/CTPPS/test/totemt2_dqm_test_common_cfg.py
+++ b/DQM/CTPPS/test/totemt2_dqm_test_common_cfg.py
@@ -53,6 +53,8 @@ process.load("RecoPPS.Configuration.recoCTPPS_cff")
 # CTPPS DQM modules
 process.load("DQM.CTPPS.ctppsDQM_cff")
 
+process.totemT2DQMSource.specialRunT2 = True
+
 process.path = cms.Path(
   process.ctppsRawToDigi *
   process.recoCTPPS *

--- a/RecoPPS/Configuration/python/RecoCTPPS_EventContent_cff.py
+++ b/RecoPPS/Configuration/python/RecoCTPPS_EventContent_cff.py
@@ -14,11 +14,6 @@ RecoCTPPSAOD = cms.PSet(
     'keep TotemRPUVPatternedmDetSetVector_totemRPUVPatternFinder_*_*',
     'keep TotemRPLocalTrackedmDetSetVector_totemRPLocalTrackFitter_*_*',
 
-    # totem T2
-    'keep TotemFEDInfos_totemT2Digis_*_*',
-    'keep TotemT2DigiedmNewDetSetVector_totemT2Digis_*_*',
-    'keep TotemVFATStatusedmDetSetVector_totemT2Digis_*_*',
-
     # timing diamonds
     'keep TotemFEDInfos_ctppsDiamondRawToDigi_*_*',
     'keep CTPPSDiamondDigiedmDetSetVector_ctppsDiamondRawToDigi_*_*',


### PR DESCRIPTION
#### PR description:

For the TOTEM special foreseen on 25.6.2023, the new T2 telescope will be used (and removed after the run) to measure inelastic rate and veto diffractive p+p collisions, when measuring the elastic p+p cross section. The code used for data taking will be a special branch off 13_0_7, 13_0_7_TOTEM_X.

The T2 DQM plots in 13_2_X and later will now be switched off by default, as requested in this approval: https://github.com/cms-sw/cmssw/pull/41922#issuecomment-1588454016 , (although the CTPPS DQM calibration mode is already off by default, so creating no T2 DQM plots in regular data taking).
Similarly, the previous removal of the T2 rechits from RecoPPS.Configuration.recoCTPPS_cfg.py is here supplemented with the removal of the "keep" output commands for T2 Digi classes.

#### PR validation:

The DQM analysis was run on a T2+TrackingStrips test file, with the specialRunT2 switch off and on, producing the expected presence of Strips only, and Strips + T2 plots.

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

Not a backport.

<!-- Please delete the text above after you verified all points of the checklist  -->
